### PR TITLE
.gitignore, workflows, and docker containers oh my!

### DIFF
--- a/.github/workflows/manual-docker-TEtranscripts.yml
+++ b/.github/workflows/manual-docker-TEtranscripts.yml
@@ -1,0 +1,23 @@
+
+name: TEtranscripts Manual Docker Workflow
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      name: Check out code
+
+    - uses: mr-smithers-excellent/docker-build-push@v5
+      name: Build & push Docker image
+      with:
+        image: <input_docker_account_here>/tetranscripts
+        tags: v1, latest
+        registry: docker.io
+        dockerfile: Dockerfile.mhammell-laboratory.TEtranscripts
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/manual-docker-TEtranscripts.yml
+++ b/.github/workflows/manual-docker-TEtranscripts.yml
@@ -18,6 +18,6 @@ jobs:
         image: <input_docker_account_here>/tetranscripts
         tags: v1, latest
         registry: docker.io
-        dockerfile: Dockerfile.mhammell-laboratory.TEtranscripts
+        dockerfile: Dockerfile
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/stale-TEtranscripts.yml
+++ b/.github/workflows/stale-TEtranscripts.yml
@@ -1,0 +1,29 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '36 2 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
+        stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        days-before-stale: 30
+        days-before-close: 5

--- a/.github/workflows/whitespace-TEtranscripts.yml
+++ b/.github/workflows/whitespace-TEtranscripts.yml
@@ -1,0 +1,21 @@
+name: Trailing Whitespace
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  example:
+    name: Find Trailing Whitespace
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: harupy/find-trailing-whitespace@master

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,17 @@
+###################
 # Compiled source #
 ###################
 *.com
 *.class
+*.d
 *.dll
 *.exe
 *.o
 *.so
 *.pyc
 *.pyo
- 
+
+############
 # Packages #
 ############
 # it's better to unpack these files and commit the raw source
@@ -21,28 +24,228 @@
 *.rar
 *.tar
 *.zip
- 
+
+######################
 # Logs and databases #
 ######################
 *.log
 nohup.out
 *.sql
 *.sqlite
- 
+
+###################### 
 # OS generated files #
 ######################
-.DS_Store
-.DS_Store?
-._*
-.Spotlight-V100
-.Trashes
-ehthumbs.db
-Thumbs.db
 
-# Backup files #
-################
+### Linux ###
 *~
-*#
-*.bak
-*.swp
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# iCloud generated files
+*.icloud
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+#####################
+# Text Editor Files #
+#####################
+
 *.orig
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data
+
+
+### LibreOffice ###
+# LibreOffice locks
+.~lock.*#
+
+### MicrosoftOffice ###
+*.tmp
+
+# Word temporary
+~$*.doc*
+
+# Word Auto Backup File
+Backup of *.doc*
+
+# Excel temporary
+~$*.xls*
+
+# Excel Backup File
+*.xlk
+
+# PowerPoint temporary
+~$*.ppt*
+
+# Visio autosave temporary files
+*.~vsd*
+
+### NotepadPP ###
+# Notepad++ backups #
+*.bak
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+#################
+# Biology Files #
+#################
+
+*.fasta
+*.fastq
+*.fasta.gz
+*.fastq.gz
+*.sam
+*.bam
+*.bg2
+
+#####################
+# Pythong Packaging #
+#####################
+
+.Python
+build/
+develop-eggs/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python
+
+#PREAMBLE
+
+WORKDIR /home/genomics
+COPY . /home/genomics
+RUN cd /home/genomics
+
+RUN apt-get --assume-yes update \
+	&& apt-get --assume-yes upgrade
+
+#MAIN
+
+RUN apt-get --assume-yes install r-base 
+
+RUN  R -e "install.packages('BiocManager', dependencies=TRUE, repos='http://cran.rstudio.com/'); BiocManager::install()" \
+	&& R -e "BiocManager::install(\"DESeq2\")" \
+	&& pip install pysam \
+	&& pip install TEtranscripts \
+	&& rm -rf *.tgz *.tar *.zip \
+	&& rm -rf /var/cache/apk/* \
+	&& rm -rf /tmp/*


### PR DESCRIPTION
This pull request does three things:
1. adds a more robust .gitignore
2. adds a workflow for making TEtoolkit docker containers (and singularity containers by proxy)
3. adds a whitespace and a stale github workflow

in order for this to work the following secrets would need to be added to the repo:

secrets.GITHUB_TOKEN
secrets.DOCKER_USERNAME
secrets.DOCKER_PASSWORD

This would necessitate a dockerhub account: https://hub.docker.com/ 

The account name from the dockerhub account would need to be added to manual-docker-TEtranscripts.yml; I recommend editing this pull request with the dockerhub userid in manual-docker-TEtranscripts.yml  before accepting the pull quest 